### PR TITLE
Add Tableau APIs to Airflow and Notebooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default:
 
 .PHONY: ubuntu notebook nodejs postgres gitlab-runner java flyway airflow node-red ratticdb sentry php-fpm ruby cachet cachet-monitor minio confluent-platform kafka-connect
 
-all: ubuntu python java flyway airflow nodejs node-red postgres gitlab-runner cachet cachet-monitor
+all: ubuntu python java flyway airflow nodejs node-red postgres gitlab-runner cachet cachet-monitor notebook
 
 ubuntu notebook nodejs postgres gitlab-runner php-fpm ruby cachet-monitor minio confluent-platform kafka-connect:
 	$(DOCKER) build -t $(ORG)/$(@) ./$(@)/

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -46,6 +46,14 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
     && apt-get install -yqq --no-install-recommends \
         google-cloud-sdk
 
+RUN mkdir extractapi \
+	&& wget -q https://downloads.tableau.com/tssoftware/extractapi-py-linux-x86_64-2019-1-3.tar.gz -O extractapi.tar.gz \
+	&& tar -xvf extractapi.tar.gz -C extractapi --strip 1 \
+	&& rm extractapi.tar.gz \
+	&& cd extractapi \
+	&& python setup.py build install \
+	&& cd .. && rm -r extractapi
+
 ENV FLYWAY_VERSION 3.2.1
 RUN wget -qO- http://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz | tar xzf - \
     && mv flyway-${FLYWAY_VERSION} /opt/flyway-${FLYWAY_VERSION}

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu xenial main" > /etc/
     && pip install scikit-learn \
     && pip install surprise \
     && pip install elasticsearch==5.5.1 \
+	&& pip install tableauserverclient \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
     && chown -R airflow: ${AIRFLOW_HOME} \
     && apt-get clean \

--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get install -yqq --no-install-recommends \
       wget \
       build-essential \
-      libpng12-dev \
+      libpng-dev \
       libfreetype6-dev \
       libopenblas-dev \
       liblapack-dev \
@@ -22,10 +22,6 @@ RUN apt-get update \
       liblz4-dev \
       libsasl2-dev \
       gfortran \
-    && ln -s /usr/include/freetype2/ft2build.h /usr/include/ \
-    && pip --no-cache-dir install pymc3 \
-    && conda install mkl mkl-service mkl-rt \
-    && conda install -y -c conda-forge bqplot \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
        /tmp/* \
@@ -33,6 +29,13 @@ RUN apt-get update \
        /usr/share/man \
        /usr/share/doc \
        /usr/share/doc-base
+
+RUN ln -s /usr/include/freetype2/ft2build.h /usr/include/
+
+RUN pip --no-cache-dir uninstall -y numpy # fix weird problem
+RUN conda update conda \
+    && conda install -y pymc3 anaconda bqplot \
+    && rm -rf /tmp/* /var/tmp/*
 
 RUN wget -qO- https://github.com/edenhill/librdkafka/archive/${LIBRDKAFKA_VERSION}.tar.gz | tar xzf - \
     && cd librdkafka-${LIBRDKAFKA_VERSION} \
@@ -45,6 +48,14 @@ RUN wget -qO- https://github.com/edenhill/librdkafka/archive/${LIBRDKAFKA_VERSIO
 COPY requirements-3.txt /requirements-3.txt
 
 RUN pip --no-cache-dir install --ignore-installed -r /requirements-3.txt
+
+RUN mkdir extractapi \
+	&& wget -q https://downloads.tableau.com/tssoftware/extractapi-py-linux-x86_64-2019-1-3.tar.gz -O extractapi.tar.gz \
+	&& tar -xvf extractapi.tar.gz -C extractapi --strip 1 \
+	&& rm extractapi.tar.gz \
+	&& cd extractapi \
+	&& python setup.py build install \
+	&& cd .. && rm -r extractapi
 
 RUN ln -s $HOME/work /notebooks
 

--- a/notebook/requirements-3.txt
+++ b/notebook/requirements-3.txt
@@ -22,3 +22,4 @@ pygal
 pandas-gbq
 matplotlib_venn
 user_agents
+tableauserverclient


### PR DESCRIPTION
Adds the Tableau Extract API and the Tableau Server Client Python APIs to the `notebooks` and `airflow` images.
The idea is we can use these APIs to do processing of BigQuery data that's in JSON columns and create either aggregates or just straight conversions into Extract files, which we can upload to Tableau and do analysis on.

API docs:
https://tableau.github.io/server-client-python/#
https://onlinehelp.tableau.com/v10.5/api/extract_api/en-us/help.htm

I had to change some package installation stuff to get it to build, presumably because of bitrot. I ran the notebooks server locally and I believe everything was working okay, I had some problems with numpy.
We should save backup copies of the current repository images before building and overwriting with these.

